### PR TITLE
Refactoring Repository Pattern for Skill Management

### DIFF
--- a/Services/Skill/classes/class.ilBasicSkill.php
+++ b/Services/Skill/classes/class.ilBasicSkill.php
@@ -2,9 +2,6 @@
 
 /* Copyright (c) 1998-2013 ILIAS open source, Extended GPL, see docs/LICENSE */
 
-include_once("./Services/Skill/classes/class.ilSkillTreeNode.php");
-include_once("./Services/Skill/interfaces/interface.ilSkillUsageInfo.php");
-
 /**
  * Basic Skill
  *
@@ -16,7 +13,7 @@ include_once("./Services/Skill/interfaces/interface.ilSkillUsageInfo.php");
 class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 {
 	/**
-	 * @var ilDB
+	 * @var ilDBInterface
 	 */
 	protected $db;
 
@@ -25,6 +22,22 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	 */
 	protected $user;
 
+	/**
+	 * @var ilBasicSkillLevelRepository
+	 */
+	protected $bsc_skl_lvl_db_rep;
+
+	/**
+	 * @var ilBasicSkillUserLevelRepository
+	 */
+	protected $bsc_skl_usr_lvl_db_rep;
+
+	/**
+	 * @var ilBasicSkillTreeRepository
+	 */
+	protected $bsc_skl_tre_rep;
+
+	//TODO: What to do with these constants?
 	const ACHIEVED = 1;
 	const NOT_ACHIEVED = 0;
 
@@ -38,12 +51,37 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	 * Constructor
 	 * @access	public
 	 */
-	function __construct($a_id = 0)
+	public function __construct(int $a_id = 0,
+								ilBasicSkillLevelDBRepository $bsc_skl_lvl_db_rep = null,
+								ilBasicSkillUserLevelDBRepository $bsc_skl_usr_lvl_db_rep = null,
+								ilBasicSkillTreeDBRepository $bsc_skl_tre_rep = null)
 	{
 		global $DIC;
 
 		$this->db = $DIC->database();
 		$this->user = $DIC->user();
+
+		if (is_null($bsc_skl_lvl_db_rep)) {
+			$this->bsc_skl_lvl_db_rep = new ilBasicSkillLevelDBRepository(
+				$this->db,
+				$this->getId()
+			);
+		}
+
+		if (is_null($bsc_skl_usr_lvl_db_rep)) {
+			$this->bsc_skl_usr_lvl_db_rep = new ilBasicSkillUserLevelDBRepository(
+				$this->db,
+				$this->getId(),
+				$this->getLevelData()
+			);
+		}
+
+		if (is_null($bsc_skl_tre_rep)) {
+			$this->bsc_skl_tre_rep = new ilBasicSkillTreeDBRepository(
+				$this->db
+			);
+		}
+
 		parent::__construct($a_id);
 		$this->setType("skll");
 	}
@@ -51,7 +89,7 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	/**
 	 * Read data from database
 	 */
-	function read()
+	public function read()
 	{
 		parent::read();
 	}
@@ -60,7 +98,7 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	 * Create skill
 	 *
 	 */
-	function create()
+	public function create()
 	{
 		parent::create();
 	}
@@ -68,17 +106,10 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	/**
 	 * Delete skill
 	 */
-	function delete()
+	public function delete()
 	{
-		$ilDB = $this->db;
-
-		$ilDB->manipulate("DELETE FROM skl_level WHERE "
-			." skill_id = ".$ilDB->quote($this->getId(), "integer")
-			);
-
-		$ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
-			." skill_id = ".$ilDB->quote($this->getId(), "integer")
-			);
+		$this->bsc_skl_lvl_db_rep->deleteLevelsOfSkill();
+		$this->bsc_skl_usr_lvl_db_rep->deleteUserLevelsOfSkill();
 
 		parent::delete();
 	}
@@ -86,7 +117,7 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	/**
 	 * Copy basic skill
 	 */
-	function copy()
+	public function copy()
 	{
 		$skill = new ilBasicSkill();
 		$skill->setTitle($this->getTitle());
@@ -108,263 +139,94 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 		return $skill;
 	}
 
+
 	//
 	//
 	// Skill level related methods
 	//
 	//
 
-	/**
-	 * Add new level
-	 *
-	 * @param	string	title
-	 * @param	string	description
-	 */
-	function addLevel($a_title, $a_description, $a_import_id = "")
+	public function addLevel(string $a_title, string $a_description, string $a_import_id = "")
 	{
-		$ilDB = $this->db;
-
-		$nr = $this->getMaxLevelNr();
-		$nid = $ilDB->nextId("skl_level");
-		$ilDB->insert("skl_level", array(
-				"id" => array("integer", $nid),
-				"skill_id" => array("integer", $this->getId()),
-				"nr" => array("integer", $nr+1),
-				"title" => array("text", $a_title),
-				"description" => array("clob", $a_description),
-				"import_id" => array("text", $a_import_id),
-				"creation_date" => array("timestamp", ilUtil::now())
-			));
-
+		$this->bsc_skl_lvl_db_rep->addLevel($a_title, $a_description, $a_import_id);
 	}
 
-	/**
-	 * Get maximum level nr
-	 *
-	 * @return	int		maximum level nr of skill
-	 */
-	function getMaxLevelNr()
+	public function getLevelData(int $a_id = 0) : array
 	{
-		$ilDB = $this->db;
-
-		$set = $ilDB->query("SELECT MAX(nr) mnr FROM skl_level WHERE ".
-			" skill_id = ".$ilDB->quote($this->getId(), "integer")
-			);
-		$rec = $ilDB->fetchAssoc($set);
-		return (int) $rec["mnr"];
+		return $this->bsc_skl_lvl_db_rep->getLevelData($a_id);
 	}
 
-	/**
-	 * Get level data
-	 *
-	 * @return	array	level data
-	 */
-	function getLevelData($a_id = 0)
-	{
-		$ilDB = $this->db;
-
-		if ($a_id > 0)
-		{
-			$and = " AND id = ".$ilDB->quote($a_id, "integer");
-		}
-
-		$set = $ilDB->query("SELECT * FROM skl_level WHERE ".
-			" skill_id = ".$ilDB->quote($this->getId(), "integer").
-			$and.
-			" ORDER BY nr"
-			);
-		$levels = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			if ($a_id > 0)
-			{
-				return $rec;
-			}
-			$levels[] = $rec;
-		}
-		return $levels;
-	}
-
-	/**
-	 * Lookup level property
-	 *
-	 * @param	id		level id
-	 * @return	mixed	property value
-	 */
-	protected static function lookupLevelProperty($a_id, $a_prop)
+	public static function lookupLevelTitle(int $a_id) : string
 	{
 		global $DIC;
 
 		$ilDB = $DIC->database();
 
-		$set = $ilDB->query("SELECT $a_prop FROM skl_level WHERE ".
-			" id = ".$ilDB->quote($a_id, "integer")
-		);
-		$rec = $ilDB->fetchAssoc($set);
-		return $rec[$a_prop];
+		$repository = new ilBasicSkillLevelDBRepository($ilDB);
+		return $repository->lookupLevelTitle($a_id);
 	}
 
-	/**
-	 * Lookup level title
-	 *
-	 * @param	int		level id
-	 * @return	string	level title
-	 */
-	static function lookupLevelTitle($a_id)
-	{
-		return ilBasicSkill::lookupLevelProperty($a_id, "title");
-	}
-
-	/**
-	 * Lookup level description
-	 *
-	 * @param	int		level id
-	 * @return	string	level description
-	 */
-	static function lookupLevelDescription($a_id)
-	{
-		return ilBasicSkill::lookupLevelProperty($a_id, "description");
-	}
-
-	/**
-	 * Lookup level skill id
-	 *
-	 * @param	int		level id
-	 * @return	string	skill id
-	 */
-	static function lookupLevelSkillId($a_id)
-	{
-		return ilBasicSkill::lookupLevelProperty($a_id, "skill_id");
-	}
-
-	/**
-	 * Write level property
-	 *
-	 * @param
-	 * @return
-	 */
-	static protected function writeLevelProperty($a_id, $a_prop, $a_value, $a_type)
+	public static function lookupLevelDescription(int $a_id) : string
 	{
 		global $DIC;
 
 		$ilDB = $DIC->database();
 
-		$ilDB->update("skl_level", array(
-			$a_prop => array($a_type, $a_value),
-			), array(
-			"id" => array("integer", $a_id),
-		));
+		$repository = new ilBasicSkillLevelDBRepository($ilDB);
+		return $repository->lookupLevelDescription($a_id);
 	}
 
-	/**
-	 * Write level title
-	 *
-	 * @param	int		level id
-	 * @param	text	level title
-	 */
-	static function writeLevelTitle($a_id, $a_title)
+	public static function lookupLevelSkillId(int $a_id) : int
 	{
-		ilBasicSkill::writeLevelProperty($a_id, "title", $a_title, "text");
+		global $DIC;
+
+		$ilDB = $DIC->database();
+
+		$repository = new ilBasicSkillLevelDBRepository($ilDB);
+		return $repository->lookupLevelSkillId($a_id);
 	}
 
-	/**
-	 * Write level description
-	 *
-	 * @param	int		level id
-	 * @param	text	level description
-	 */
-	static function writeLevelDescription($a_id, $a_description)
+	public static function writeLevelTitle(int $a_id, string $a_title)
 	{
-		ilBasicSkill::writeLevelProperty($a_id, "description", $a_description, "clob");
+		global $DIC;
+
+		$ilDB = $DIC->database();
+
+		$repository = new ilBasicSkillLevelDBRepository($ilDB);
+		$repository->writeLevelTitle($a_id, $a_title);
 	}
 
-	/**
-	 * Update level order
-	 *
-	 * @param
-	 * @return
-	 */
-	function updateLevelOrder($order)
+	public static function writeLevelDescription(int $a_id, string $a_description)
 	{
-		$ilDB = $this->db;
+		global $DIC;
 
+		$ilDB = $DIC->database();
+
+		$repository = new ilBasicSkillLevelDBRepository($ilDB);
+		$repository->writeLevelDescription($a_id, $a_description);
+	}
+
+	public function updateLevelOrder(array $order)
+	{
 		asort($order);
-
-		$cnt = 1;
-		foreach ($order as $id => $o)
-		{
-			$ilDB->manipulate("UPDATE skl_level SET ".
-				" nr = ".$ilDB->quote($cnt, "integer").
-				" WHERE id = ".$ilDB->quote($id, "integer")
-				);
-			$cnt++;
-		}
+		$this->bsc_skl_lvl_db_rep->updateLevelOrder($order);
 	}
 
-	/**
-	 * Delete level
-	 *
-	 * @param
-	 * @return
-	 */
-	function deleteLevel($a_id)
+	public function deleteLevel(int $a_id)
 	{
-		$ilDB = $this->db;
-
-		$ilDB->manipulate("DELETE FROM skl_level WHERE "
-			." id = ".$ilDB->quote($a_id, "integer")
-			);
-
+		$this->bsc_skl_lvl_db_rep->deleteLevel($a_id);
 	}
 
-	/**
-	 * Fix level numbering
-	 *
-	 * @param
-	 * @return
-	 */
-	function fixLevelNumbering()
+	public function fixLevelNumbering()
 	{
-		$ilDB = $this->db;
-
-		$set = $ilDB->query("SELECT id, nr FROM skl_level WHERE ".
-			" skill_id = ".$ilDB->quote($this->getId(), "integer").
-			" ORDER BY nr ASC"
-		);
-		$cnt = 1;
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$ilDB->manipulate("UPDATE skl_level SET ".
-				" nr = ".$ilDB->quote($cnt, "integer").
-				" WHERE id = ".$ilDB->quote($rec["id"], "integer")
-				);
-			$cnt++;
-		}
+		$this->bsc_skl_lvl_db_rep->fixLevelNumbering();
 	}
 
-	/**
-	 * Get skill for level id
-	 *
-	 * @param
-	 * @return
-	 */
-	function getSkillForLevelId($a_level_id)
+	public function getSkillForLevelId(int $a_level_id)
 	{
-		$ilDB = $this->db;
-
-		$set = $ilDB->query("SELECT * FROM skl_level WHERE ".
-			" id = ".$ilDB->quote($a_level_id, "integer")
-			);
-		$skill = null;
-		if ($rec = $ilDB->fetchAssoc($set))
-		{
-			if (ilSkillTreeNode::isInTree($rec["skill_id"]))
-			{
-				$skill = new ilBasicSkill($rec["skill_id"]);
-			}
-		}
-		return $skill;
+		return $this->bsc_skl_lvl_db_rep->getSkillForLevelId($a_level_id);
 	}
+
 
 	//
 	//
@@ -372,182 +234,64 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	//
 	//
 
-
-	/**
-	 * Reset skill level status. This is currently only used for self evaluations with a "no competence" level.
-	 * It has to be discussed, how this should be provided for non-self-evaluations.
-	 *
-	 * @param int $a_user_id user id
-	 * @param int $a_skill_id skill id
-	 * @param int $a_tref_id skill tref id
-	 * @param int $a_trigger_ref_id triggering repository object ref id
-	 * @param bool $a_self_eval currently needs to be set to true
-	 *
-	 * @throws ilSkillException
-	 */
-	static function resetUserSkillLevelStatus($a_user_id, $a_skill_id, $a_tref_id = 0, $a_trigger_ref_id = 0, $a_self_eval = false)
+	public static function resetUserSkillLevelStatus(int $a_user_id, int $a_skill_id, int $a_tref_id = 0,
+											  int $a_trigger_ref_id = 0, bool $a_self_eval = false)
 	{
 		global $DIC;
 
-		$db = $DIC->database();
+		$ilDB = $DIC->database();
 
 		if (!$a_self_eval)
 		{
-			include_once("./Services/Skill/exceptions/class.ilSkillException.php");
 			throw new ilSkillException("resetUserSkillLevelStatus currently only provided for self evaluations.");
 		}
 
+		$obj_adapter = new ilSkillObjectAdapter();
 		$trigger_obj_id = ($a_trigger_ref_id > 0)
-			? ilObject::_lookupObjId($a_trigger_ref_id)
+			? $obj_adapter->getObjIdForRefId($a_trigger_ref_id)
 			: 0;
 
 		$update = false;
-		$status_date = self::hasRecentSelfEvaluation($a_user_id, $a_skill_id, $a_tref_id, $a_trigger_ref_id);
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		$status_date = $repository->hasRecentSelfEvaluation($a_user_id, $a_skill_id, $a_tref_id, $a_trigger_ref_id);
 		if ($status_date != "")
 		{
 			$update = true;
 		}
 
-		if ($update)
-		{
-			// this will only be set in self eval case, means this will always have a $rec
-			$now = ilUtil::now();
-			$db->manipulate("UPDATE skl_user_skill_level SET ".
-				" level_id = ".$db->quote(0, "integer").",".
-				" status_date = ".$db->quote($now, "timestamp").
-				" WHERE user_id = ".$db->quote($a_user_id, "integer").
-				" AND status_date = ".$db->quote($status_date, "timestamp").
-				" AND skill_id = ".$db->quote($a_skill_id, "integer").
-				" AND status = ".$db->quote(self::ACHIEVED, "integer").
-				" AND trigger_obj_id = ".$db->quote($trigger_obj_id, "integer").
-				" AND tref_id = ".$db->quote((int) $a_tref_id, "integer").
-				" AND self_eval = ".$db->quote($a_self_eval, "integer")
-			);
-		}
-		else
-		{
-			$now = ilUtil::now();
-			$db->manipulate("INSERT INTO skl_user_skill_level ".
-				"(level_id, user_id, tref_id, status_date, skill_id, status, valid, trigger_ref_id,".
-				"trigger_obj_id, trigger_obj_type, trigger_title, self_eval, unique_identifier) VALUES (".
-				$db->quote(0, "integer").",".
-				$db->quote($a_user_id, "integer").",".
-				$db->quote((int) $a_tref_id, "integer").",".
-				$db->quote($now, "timestamp").",".
-				$db->quote($a_skill_id, "integer").",".
-				$db->quote(self::ACHIEVED, "integer").",".
-				$db->quote(1, "integer").",".
-				$db->quote($a_trigger_ref_id, "integer").",".
-				$db->quote($trigger_obj_id, "integer").",".
-				$db->quote("", "text").",".
-				$db->quote("", "text").",".
-				$db->quote($a_self_eval, "integer").",".
-				$db->quote("", "text").
-				")");
-		}
-
-		$db->manipulate("DELETE FROM skl_user_has_level WHERE "
-			." user_id = ".$db->quote($a_user_id, "integer")
-			." AND skill_id = ".$db->quote($a_skill_id, "integer")
-			." AND tref_id = ".$db->quote((int) $a_tref_id, "integer")
-			." AND trigger_obj_id = ".$db->quote($trigger_obj_id, "integer")
-			." AND self_eval = ".$db->quote($a_self_eval, "integer")
-		);
-
+		$repository->resetUserSkillLevelStatus($update, $trigger_obj_id, $status_date, $a_user_id, $a_skill_id,
+			$a_tref_id, $a_trigger_ref_id, $a_self_eval);
 	}
 
-	/**
-	 * Has recent self evaluation. Check if self evaluation for user/object has been done on the same day
-	 * already
-	 *
-	 * @param
-	 * @return
-	 */
-	protected static function hasRecentSelfEvaluation($a_user_id, $a_skill_id, $a_tref_id = 0, $a_trigger_ref_id = 0)
+	protected static function hasRecentSelfEvaluation(int $a_user_id, int $a_skill_id, int $a_tref_id = 0, int $a_trigger_ref_id = 0)
 	{
 		global $DIC;
 
-		$db = $DIC->database();
+		$ilDB = $DIC->database();
 
+		$obj_adapter = new ilSkillObjectAdapter();
 		$trigger_obj_id = ($a_trigger_ref_id > 0)
-			? ilObject::_lookupObjId($a_trigger_ref_id)
+			? $obj_adapter->getObjIdForRefId($a_trigger_ref_id)
 			: 0;
 
-		$recent = "";
-
-		$db->setLimit(1);
-		$set = $db->query("SELECT * FROM skl_user_skill_level WHERE ".
-			"skill_id = ".$db->quote($a_skill_id, "integer")." AND ".
-			"user_id = ".$db->quote($a_user_id, "integer")." AND ".
-			"tref_id = ".$db->quote((int) $a_tref_id, "integer")." AND ".
-			"trigger_obj_id = ".$db->quote($trigger_obj_id, "integer")." AND ".
-			"self_eval = ".$db->quote(1, "integer").
-			" ORDER BY status_date DESC"
-		);
-		$rec = $db->fetchAssoc($set);
-		$status_day = substr($rec["status_date"], 0, 10);
-		$today = substr(ilUtil::now(), 0, 10);
-		if ($rec["valid"] && $rec["status"] == ilBasicSkill::ACHIEVED && $status_day == $today)
-		{
-			$recent = $rec["status_date"];
-		}
-
-		return $recent;
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		return $repository->hasRecentSelfEvaluation($trigger_obj_id, $a_user_id, $a_skill_id, $a_tref_id, $a_trigger_ref_id);
 	}
 
-	/**
-	 * Get new achievements
-	 *
-	 * @param string $a_timestamp
-	 * @return array
-	 */
-	static function getNewAchievementsPerUser($a_timestamp, $a_timestamp_to = null, $a_user_id = 0, $a_self_eval = 0)
+	public static function getNewAchievementsPerUser(string $a_timestamp, string $a_timestamp_to = null,
+											  int $a_user_id = 0, int $a_self_eval = 0) : array
 	{
 		global $DIC;
 
-		$db = $DIC->database();
+		$ilDB = $DIC->database();
 
-		$to = (!is_null($a_timestamp_to))
-			? " AND status_date <= ".$db->quote($a_timestamp_to, "timestamp")
-			: "";
-
-		$user = ($a_user_id > 0)
-			? " AND user_id = ".$db->quote($a_user_id, "integer")
-			: "";
-
-		$set = $db->query("SELECT * FROM skl_user_skill_level ".
-			" WHERE status_date >= ".$db->quote($a_timestamp, "timestamp").
-			" AND valid = ".$db->quote(1, "integer").
-			" AND status = ".$db->quote(ilBasicSkill::ACHIEVED, "integer").
-			" AND self_eval = ".$db->quote($a_self_eval, "integer").
-			$to.
-			$user.
-			" ORDER BY user_id, status_date ASC ");
-		$achievments = array();
-		while ($rec = $db->fetchAssoc($set))
-		{
-			$achievments[$rec["user_id"]][] = $rec;
-		}
-
-		return $achievments;
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		return $repository->getNewAchievementsPerUser($a_timestamp, $a_timestamp_to, $a_user_id, $a_self_eval);
 	}
 
-
-	/**
-	 * Write skill level status
-	 *
-	 * @param int $a_level_id skill level id
-	 * @param int $a_user_id user id
-	 * @param int $a_trigger_ref_id trigger repository object ref id
-	 * @param int $a_tref_id skill tref id
-	 * @param int $a_status DEPRECATED, always use ilBasicSkill::ACHIEVED
-	 * @param bool $a_force DEPRECATED
-	 * @param bool $a_self_eval self evaluation
-	 * @param string $a_unique_identifier a  unique identifier (should be used with trigger_ref_id > 0)
-	 */
-	static function writeUserSkillLevelStatus($a_level_id, $a_user_id,
-		$a_trigger_ref_id, $a_tref_id = 0, $a_status = ilBasicSkill::ACHIEVED, $a_force = false,
-		$a_self_eval = false, $a_unique_identifier = "")
+	public static function writeUserSkillLevelStatus(int $a_level_id, int $a_user_id, int $a_trigger_ref_id, int $a_tref_id = 0,
+											  int $a_status = ilBasicSkill::ACHIEVED, bool $a_force = false,
+											  bool $a_self_eval = false, string $a_unique_identifier = "")
 	{
 		global $DIC;
 
@@ -555,9 +299,10 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 
 		$skill_id = ilBasicSkill::lookupLevelSkillId($a_level_id);
 		$trigger_ref_id = $a_trigger_ref_id;
-		$trigger_obj_id = ilObject::_lookupObjId($trigger_ref_id);
-		$trigger_title = ilObject::_lookupTitle($trigger_obj_id);
-		$trigger_type = ilObject::_lookupType($trigger_obj_id);
+		$obj_adapter = new ilSkillObjectAdapter();
+		$trigger_obj_id = $obj_adapter->getObjIdForRefId($trigger_ref_id);
+		$trigger_title = $obj_adapter->getTitleForObjId($trigger_obj_id);
+		$trigger_type = $obj_adapter->getTypeForObjId($trigger_obj_id);
 
 		$update = false;
 
@@ -571,427 +316,119 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 			}
 		}
 
-		if ($update)
-		{
-			// this will only be set in self eval case, means this will always have a $rec
-			$now = ilUtil::now();
-			$ilDB->manipulate("UPDATE skl_user_skill_level SET ".
-				" level_id = ".$ilDB->quote($a_level_id, "integer").",".
-				" status_date = ".$ilDB->quote($now, "timestamp").
-				" WHERE user_id = ".$ilDB->quote($a_user_id, "integer").
-				" AND status_date = ".$ilDB->quote($status_date, "timestamp").
-				" AND skill_id = ".$ilDB->quote($skill_id, "integer").
-				" AND status = ".$ilDB->quote($a_status, "integer").
-				" AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer").
-				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-				" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
-				);
-		}
-		else
-		{
-			if ($a_unique_identifier != "")
-			{
-				$ilDB->manipulate("DELETE FROM skl_user_skill_level WHERE ".
-					" user_id = ".$ilDB->quote($a_user_id, "integer").
-					" AND tref_id = ".$ilDB->quote($a_tref_id, "integer").
-					" AND skill_id = ".$ilDB->quote($skill_id, "integer").
-					" AND trigger_ref_id = ".$ilDB->quote($trigger_ref_id, "integer").
-					" AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer").
-					" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
-					" AND unique_identifier = ".$ilDB->quote($a_unique_identifier, "text")
-				);
-			}
-
-			$now = ilUtil::now();
-			$ilDB->manipulate("INSERT INTO skl_user_skill_level ".
-				"(level_id, user_id, tref_id, status_date, skill_id, status, valid, trigger_ref_id,".
-				"trigger_obj_id, trigger_obj_type, trigger_title, self_eval, unique_identifier) VALUES (".
-				$ilDB->quote($a_level_id, "integer").",".
-				$ilDB->quote($a_user_id, "integer").",".
-				$ilDB->quote((int) $a_tref_id, "integer").",".
-				$ilDB->quote($now, "timestamp").",".
-				$ilDB->quote($skill_id, "integer").",".
-				$ilDB->quote($a_status, "integer").",".
-				$ilDB->quote(1, "integer").",".
-				$ilDB->quote($trigger_ref_id, "integer").",".
-				$ilDB->quote($trigger_obj_id, "integer").",".
-				$ilDB->quote($trigger_type, "text").",".
-				$ilDB->quote($trigger_title, "text").",".
-				$ilDB->quote($a_self_eval, "integer").",".
-				$ilDB->quote($a_unique_identifier, "text").
-				")");
-		}
-
-		// fix (removed level_id and added skill id, since table should hold only
-		// one entry per skill)
-		$ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
-			." user_id = ".$ilDB->quote($a_user_id, "integer")
-			." AND skill_id = ".$ilDB->quote($skill_id, "integer")
-			." AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer")
-			." AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer")
-			." AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
-		);
-
-		if ($a_status == ilBasicSkill::ACHIEVED)
-		{
-			$ilDB->manipulate("INSERT INTO skl_user_has_level ".
-			"(level_id, user_id, tref_id, status_date, skill_id, trigger_ref_id, trigger_obj_id, trigger_obj_type, trigger_title, self_eval) VALUES (".
-			$ilDB->quote($a_level_id, "integer").",".
-			$ilDB->quote($a_user_id, "integer").",".
-			$ilDB->quote($a_tref_id, "integer").",".
-			$ilDB->quote($now, "timestamp").",".
-			$ilDB->quote($skill_id, "integer").",".
-			$ilDB->quote($trigger_ref_id, "integer").",".
-			$ilDB->quote($trigger_obj_id, "integer").",".
-			$ilDB->quote($trigger_type, "text").",".
-			$ilDB->quote($trigger_title, "text").",".
-			$ilDB->quote($a_self_eval, "integer").
-			")");
-		}
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		$repository->writeUserSkillLevelStatus($skill_id, $trigger_ref_id, $trigger_obj_id, $trigger_title,
+			$trigger_type, $update, $status_date, $a_level_id, $a_user_id, $a_tref_id, $a_status, $a_force,
+			$a_self_eval, $a_unique_identifier);
 	}
 
-	/**
-	 * Remove a user skill completely
-	 *
-	 * @param int $a_user_id user id
-	 * @param int $a_trigger_obj_id triggering repository object obj id
-	 * @param bool $a_self_eval currently needs to be set to true
-	 * @param string $a_unique_identifier unique identifier string
-	 * @return bool true, if entries have been deleted, otherwise false
-	 */
-	static function removeAllUserSkillLevelStatusOfObject($a_user_id, $a_trigger_obj_id, $a_self_eval = false, $a_unique_identifier = "")
+	public static function removeAllUserSkillLevelStatusOfObject(int $a_user_id, int $a_trigger_obj_id, bool $a_self_eval = false,
+														  string $a_unique_identifier = "") : bool
 	{
 		global $DIC;
 
-		$db = $DIC->database();
+		$ilDB = $DIC->database();
 
 		if ($a_trigger_obj_id == 0)
 		{
 			return false;
 		}
 
-		$changed = false;
-
-		$aff_rows = $db->manipulate("DELETE FROM skl_user_skill_level WHERE "
-			." user_id = ".$db->quote($a_user_id, "integer")
-			." AND trigger_obj_id = ".$db->quote($a_trigger_obj_id, "integer")
-			." AND self_eval = ".$db->quote($a_self_eval, "integer")
-			." AND unique_identifier = ".$db->quote($a_unique_identifier, "text")
-		);
-		if ($aff_rows > 0)
-		{
-			$changed = true;
-		}
-
-		$aff_rows = $db->manipulate("DELETE FROM skl_user_has_level WHERE "
-			." user_id = ".$db->quote($a_user_id, "integer")
-			." AND trigger_obj_id = ".$db->quote($a_trigger_obj_id, "integer")
-			." AND self_eval = ".$db->quote($a_self_eval, "integer")
-		);
-		if ($aff_rows > 0)
-		{
-			$changed = true;
-		}
-		return $changed;
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		return $repository->removeAllUserSkillLevelStatusOfObject($a_user_id, $a_trigger_obj_id, $a_self_eval,
+			$a_unique_identifier);
 	}
 
-	/**
-	 * Remove all data of a user
-	 *
-	 * @param int $a_user_id
-	 */
-	static function removeAllUserData($a_user_id)
+	public static function removeAllUserData(int $a_user_id)
 	{
 		global $DIC;
 
-		$db = $DIC->database();
+		$ilDB = $DIC->database();
 
-		$db->manipulate("DELETE FROM skl_user_skill_level WHERE "
-			." user_id = ".$db->quote($a_user_id, "integer")
-		);
-		$db->manipulate("DELETE FROM skl_user_has_level WHERE "
-			." user_id = ".$db->quote($a_user_id, "integer")
-		);
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		$repository->removeAllUserData($a_user_id);
 	}
 
-
-	/**
-	 * Get max levels per type
-	 *
-	 * @param
-	 * @return
-	 */
-	function getMaxLevelPerType($a_tref_id, $a_type, $a_user_id = 0, $a_self_eval = 0)
+	public function getMaxLevelPerType(int $a_tref_id, string $a_type, int $a_user_id = 0, int $a_self_eval = 0) : int
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-		
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
-		
-		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
-			" WHERE trigger_obj_type = ".$ilDB->quote($a_type, "text").
-			" AND skill_id = ".$ilDB->quote($this->getId(), "integer").
-			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
-			);
 
-		$has_level = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$has_level[$rec["level_id"]] = true;
-		}
-		$max_level = 0;
-		foreach ($this->getLevelData() as $l)
-		{
-			if (isset($has_level[$l["id"]]))
-			{
-				$max_level = $l["id"];
-			}
-		}
-		return $max_level;
+		return $this->bsc_skl_usr_lvl_db_rep->getMaxLevelPerType($a_tref_id, $a_type, $a_user_id, $a_self_eval);
 	}
 
-	/**
-	 * Get all level entries
-	 *
-	 * @param
-	 * @return
-	 */
-	function getAllLevelEntriesOfUser($a_tref_id, $a_user_id = 0, $a_self_eval = 0)
+	public function getAllLevelEntriesOfUser(int $a_tref_id, int $a_user_id = 0, int $a_self_eval = 0) : array
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-		
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
-		
-		$set = $ilDB->query($q = "SELECT * FROM skl_user_has_level ".
-			" WHERE skill_id = ".$ilDB->quote($this->getId(), "integer").
-			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
-			" ORDER BY status_date DESC"
-			);
 
-		$levels = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$levels[] = $rec;
-		}
-		return $levels;
+		return $this->bsc_skl_usr_lvl_db_rep->getAllLevelEntriesOfUser($a_tref_id, $a_user_id, $a_self_eval);
 	}
 
-	/**
-	 * Get all historic level entries
-	 *
-	 * @param
-	 * @return
-	 */
-	function getAllHistoricLevelEntriesOfUser($a_tref_id, $a_user_id = 0, $a_eval_by = 0)
+	public function getAllHistoricLevelEntriesOfUser(int $a_tref_id, int $a_user_id = 0, int $a_eval_by = 0) : array
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
 
-		$by = ($a_eval_by != self::EVAL_BY_ALL)
-			? " AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
-			: "";
-
-		$set = $ilDB->query($q = "SELECT * FROM skl_user_skill_level ".
-				" WHERE skill_id = ".$ilDB->quote($this->getId(), "integer").
-				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-				" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-				$by.
-				" ORDER BY status_date DESC"
-		);
-		$levels = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$levels[] = $rec;
-		}
-		return $levels;
+		return $this->bsc_skl_usr_lvl_db_rep->getAllHistoricLevelEntriesOfUser($a_tref_id, $a_user_id, $a_eval_by);
 	}
 
-
-	/**
-	 * Get max levels per object
-	 *
-	 * @param
-	 * @return
-	 */
-	function getMaxLevelPerObject($a_tref_id, $a_object_id, $a_user_id = 0, $a_self_eval = 0)
+	public function getMaxLevelPerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0) : int
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
 
-		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
-				" WHERE trigger_obj_id = ".$ilDB->quote($a_object_id, "integer").
-				" AND skill_id = ".$ilDB->quote($this->getId(), "integer").
-				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-				" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-				" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
-		);
-
-		$has_level = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$has_level[$rec["level_id"]] = true;
-		}
-		$max_level = 0;
-		foreach ($this->getLevelData() as $l)
-		{
-			if (isset($has_level[$l["id"]]))
-			{
-				$max_level = $l["id"];
-			}
-		}
-		return $max_level;
+		return $this->bsc_skl_usr_lvl_db_rep->getMaxLevelPerObject($a_tref_id, $a_object_id, $a_user_id, $a_self_eval);
 	}
 
-	/**
-	 * Get max levels per object
-	 *
-	 * @param
-	 * @return
-	 */
-	function getMaxLevel($a_tref_id, $a_user_id = 0, $a_self_eval = 0)
+	public function getMaxLevel(int $a_tref_id, int $a_user_id = 0, int $a_self_eval = 0) : int
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
 
-		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
-			" WHERE skill_id = ".$ilDB->quote($this->getId(), "integer").
-			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
-		);
-
-		$has_level = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$has_level[$rec["level_id"]] = true;
-		}
-		$max_level = 0;
-		foreach ($this->getLevelData() as $l)
-		{
-			if (isset($has_level[$l["id"]]))
-			{
-				$max_level = $l["id"];
-			}
-		}
-		return $max_level;
+		return $this->bsc_skl_usr_lvl_db_rep->getMaxLevel($a_tref_id, $a_user_id, $a_self_eval);
 	}
 
-
-	/**
-	 * Has use self evaluated a skill?
-	 *
-	 * @param int $a_user_id
-	 * @param int $a_skill_id
-	 * @param int $a_tref_id
-	 * @return bool
-	 */
-	static function hasSelfEvaluated($a_user_id, $a_skill_id, $a_tref_id)
+	public static function hasSelfEvaluated(int $a_user_id, int $a_skill_id, int $a_tref_id) : bool
 	{
 		global $DIC;
 
-		$db = $DIC->database();
+		$ilDB = $DIC->database();
 
-		$set = $db->query($q = "SELECT level_id FROM skl_user_has_level ".
-			" WHERE skill_id = ".$db->quote((int) $a_skill_id, "integer").
-			" AND tref_id = ".$db->quote((int) $a_tref_id, "integer").
-			" AND user_id = ".$db->quote($a_user_id, "integer").
-			" AND self_eval = ".$db->quote(1, "integer")
-		);
-		
-		if ($rec = $db->fetchAssoc($set))
-		{
-			return true;
-		}
-		return false;
+		$repository = new ilBasicSkillUserLevelDBRepository($ilDB);
+		return $repository->hasSelfEvaluated($a_user_id, $a_skill_id, $a_tref_id);
 	}
 
-	/**
-	 * Get last level set per object
-	 *
-	 * @param
-	 * @return
-	 */
-	function getLastLevelPerObject($a_tref_id, $a_object_id, $a_user_id = 0, $a_self_eval = 0)
+	public function getLastLevelPerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0)
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
 
-		$ilDB->setLimit(1);
-		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
-				" WHERE trigger_obj_id = ".$ilDB->quote($a_object_id, "integer").
-				" AND skill_id = ".$ilDB->quote($this->getId(), "integer").
-				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-				" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-				" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
-				" ORDER BY status_date DESC"
-		);
-
-		$rec = $ilDB->fetchAssoc($set);
-
-		return $rec["level_id"];
+		return $this->bsc_skl_usr_lvl_db_rep->getLastLevelPerObject($a_tref_id, $a_object_id, $a_user_id, $a_self_eval);
 	}
 
-	/**
-	 * Get last update per object
-	 *
-	 * @param
-	 * @return
-	 */
-	function getLastUpdatePerObject($a_tref_id, $a_object_id, $a_user_id = 0, $a_self_eval = 0)
+	public function getLastUpdatePerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0)
 	{
-		$ilDB = $this->db;
-		$ilUser = $this->user;
-
 		if ($a_user_id == 0)
 		{
-			$a_user_id = $ilUser->getId();
+			$a_user_id = $this->user->getId();
 		}
 
-		$ilDB->setLimit(1);
-		$set = $ilDB->query($q = "SELECT status_date FROM skl_user_has_level ".
-				" WHERE trigger_obj_id = ".$ilDB->quote($a_object_id, "integer").
-				" AND skill_id = ".$ilDB->quote($this->getId(), "integer").
-				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
-				" AND user_id = ".$ilDB->quote($a_user_id, "integer").
-				" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
-				" ORDER BY status_date DESC"
-		);
-
-		$rec = $ilDB->fetchAssoc($set);
-
-		return $rec["status_date"];
+		return $this->bsc_skl_usr_lvl_db_rep->getLastUpdatePerObject($a_tref_id, $a_object_id, $a_user_id, $a_self_eval);
 	}
+
 
 	//
 	//
@@ -1002,8 +439,7 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	/**
 	 * Get title for certificate
 	 *
-	 * @param
-	 * @return
+	 * @return string
 	 */
 	function getTitleForCertificate()
 	{
@@ -1013,8 +449,7 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	/**
 	 * Get short title for certificate
 	 *
-	 * @param
-	 * @return
+	 * @return string
 	 */
 	function getShortTitleForCertificate()
 	{
@@ -1023,11 +458,11 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 
 	/**
 	 * Checks whether a skill level has a certificate or not
-	 * @param int	skill id
-	 * @param int	skill level id
-	 * @return true/false
+	 * @param int $a_skill_id skill id
+	 * @param int $a_skill_level_id skill level id
+	 * @return bool
 	 */
-	public static function _lookupCertificate($a_skill_id, $a_skill_level_id)
+	public static function _lookupCertificate(int $a_skill_id, int $a_skill_level_id)
 	{
 		$certificatefile = CLIENT_WEB_DIR."/certificates/skill/".
 			((int)$a_skill_id)."/".((int) $a_skill_level_id)."/certificate.xml";
@@ -1044,36 +479,22 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 	/**
 	 * Get usage info
 	 *
-	 * @param
-	 * @return
+	 * @param array $a_cskill_ids
+	 * @param array $a_usages
 	 */
 	static public function getUsageInfo($a_cskill_ids, &$a_usages)
 	{
-		global $DIC;
-
-		$ilDB = $DIC->database();
-		
-		include_once("./Services/Skill/classes/class.ilSkillUsage.php");
 		ilSkillUsage::getUsageInfoGeneric($a_cskill_ids, $a_usages, ilSkillUsage::USER_ASSIGNED,
 				"skl_user_skill_level", "user_id");
 	}
 
-	/**
-	 * Get common skill ids for import IDs (newest first)
-	 *
-	 * @param int $a_source_inst_id source installation id, must be <>0
-	 * @param int $a_skill_import_id source skill id (type basic skill ("skll") or basic skill template ("sktp"))
-	 * @param int $a_tref_import_id source template reference id (if > 0 skill_import_id will be of type "sktp")
-	 * @return array array of common skill ids, keys are "skill_id", "tref_id", "creation_date"
-	 */
-	static function getCommonSkillIdForImportId($a_source_inst_id, $a_skill_import_id, $a_tref_import_id = 0)
+	public static function getCommonSkillIdForImportId(int $a_source_inst_id, int $a_skill_import_id,
+													   int $a_tref_import_id = 0) : array
 	{
 		global $DIC;
 
 		$ilDB = $DIC->database();
 
-		include_once("./Services/Skill/classes/class.ilSkillTree.php");
-		include_once("./Services/Skill/classes/class.ilSkillTemplateReference.php");
 		$tree = new ilSkillTree();
 
 		if ($a_source_inst_id == 0)
@@ -1081,91 +502,31 @@ class ilBasicSkill extends ilSkillTreeNode implements ilSkillUsageInfo
 			return array();
 		}
 
-		$template_ids = array();
-		if ($a_tref_import_id > 0)
-		{
-			$skill_node_type = "sktp";
-
-			// get all matching tref nodes
-			$set = $ilDB->query("SELECT * FROM skl_tree_node n JOIN skl_tree t ON (n.obj_id = t.child) ".
-					" WHERE n.import_id = ".$ilDB->quote("il_".((int)$a_source_inst_id)."_sktr_".$a_tref_import_id, "text").
-					" ORDER BY n.creation_date DESC ");
-			while ($rec = $ilDB->fetchAssoc($set))
-			{
-				if (($t = ilSkillTemplateReference::_lookupTemplateId($rec["obj_id"])) > 0)
-				{
-					$template_ids[$t] = $rec["obj_id"];
-				}
-			}
-		}
-		else
-		{
-			$skill_node_type = "skll";
-		}
-		$set = $ilDB->query("SELECT * FROM skl_tree_node n JOIN skl_tree t ON (n.obj_id = t.child) ".
-			" WHERE n.import_id = ".$ilDB->quote("il_".((int)$a_source_inst_id)."_".$skill_node_type."_".$a_skill_import_id, "text").
-			" ORDER BY n.creation_date DESC ");
-		$results = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$matching_trefs = array();
-			if ($a_tref_import_id > 0)
-			{
-				$skill_template_id = $tree->getTopParentNodeId($rec["obj_id"]);
-
-				// check of skill is in template
-				foreach ($template_ids as $templ => $tref)
-				{
-					if ($skill_template_id == $templ)
-					{
-						$matching_trefs[] = $tref;
-					}
-				}
-			}
-			else
-			{
-				$matching_trefs = array(0);
-			}
-
-			foreach ($matching_trefs as $t)
-			{
-				$results[] = array("skill_id" => $rec["obj_id"], "tref_id" => $t, "creation_date" => $rec["creation_date"]);
-			}
-		}
-		return $results;
+		$repository = new ilBasicSkillTreeDBRepository($ilDB);
+		return $repository->getCommonSkillIdForImportId($tree, $a_source_inst_id, $a_skill_import_id, $a_tref_import_id);
 	}
 
-	/**
-	 * Get level ids for import IDs (newest first)
-	 *
-	 * @param int $a_source_inst_id source installation id, must be <>0
-	 * @param int $a_skill_import_id source skill id (type basic skill ("skll") or basic skill template ("sktp"))
-	 * @return array array of common skill ids, keys are "level_id", "creation_date"
-	 */
-	static function getLevelIdForImportId($a_source_inst_id, $a_level_import_id)
+	public static function getLevelIdForImportId(int $a_source_inst_id, int $a_level_import_id) : array
 	{
 		global $DIC;
 
 		$ilDB = $DIC->database();
 
-		$set = $ilDB->query("SELECT * FROM skl_level l JOIN skl_tree t ON (l.skill_id = t.child) " .
-				" WHERE l.import_id = " . $ilDB->quote("il_" . ((int)$a_source_inst_id) . "_sklv_" . $a_level_import_id, "text") .
-				" ORDER BY l.creation_date DESC ");
-		$results = array();
-		while ($rec = $ilDB->fetchAssoc($set))
-		{
-			$results[] = array("level_id" => $rec["id"], "creation_date" => $rec["creation_date"]);
-		}
-		return $results;
+		$repository = new ilBasicSkillTreeDBRepository($ilDB);
+		return $repository->getLevelIdForImportId($a_source_inst_id, $a_level_import_id);
 	}
 
 	/**
 	 * Get level ids for import Ids matching common skills
 	 *
-	 * @param
-	 * @return
+	 * @param int $a_source_inst_id
+	 * @param int $a_level_import_id
+	 * @param int $a_skill_import_id
+	 * @param int $a_tref_import_id
+	 *
+	 * @return array
 	 */
-	static function getLevelIdForImportIdMatchSkill($a_source_inst_id, $a_level_import_id, $a_skill_import_id, $a_tref_import_id = 0)
+	public static function getLevelIdForImportIdMatchSkill(int $a_source_inst_id, int $a_level_import_id, int $a_skill_import_id, int $a_tref_import_id = 0) : array
 	{
 		$level_id_data = self::getLevelIdForImportId($a_source_inst_id, $a_level_import_id);
 		$skill_data = self::getCommonSkillIdForImportId($a_source_inst_id, $a_skill_import_id, $a_tref_import_id);

--- a/Services/Skill/classes/class.ilBasicSkillLevelDBRepository.php
+++ b/Services/Skill/classes/class.ilBasicSkillLevelDBRepository.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * Class ilBasicSkillLevelDBRepository
+ */
+class ilBasicSkillLevelDBRepository implements ilBasicSkillLevelRepository
+{
+	/**
+	 * @var ilDBInterface
+	 */
+	protected $db;
+
+	/**
+	 * @var int
+	 */
+	protected $id;
+
+	public function __construct(ilDBInterface $db, int $id = null)
+	{
+		$this->db = $db;
+		$this->id = $id;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function deleteLevelsOfSkill()
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$ilDB->manipulate("DELETE FROM skl_level WHERE "
+			." skill_id = ".$ilDB->quote($id, "integer")
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function addLevel(string $a_title, string $a_description, string $a_import_id = "")
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$nr = $this->getMaxLevelNr();
+		$nid = $ilDB->nextId("skl_level");
+		$ilDB->insert("skl_level", array(
+			"id" => array("integer", $nid),
+			"skill_id" => array("integer", $id),
+			"nr" => array("integer", $nr+1),
+			"title" => array("text", $a_title),
+			"description" => array("clob", $a_description),
+			"import_id" => array("text", $a_import_id),
+			"creation_date" => array("timestamp", ilUtil::now())
+		));
+
+	}
+
+	/**
+	 * Get maximum level nr
+	 *
+	 * @return	int		maximum level nr of skill
+	 */
+	protected function getMaxLevelNr() : int
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$set = $ilDB->query("SELECT MAX(nr) mnr FROM skl_level WHERE ".
+			" skill_id = ".$ilDB->quote($id, "integer")
+		);
+		$rec = $ilDB->fetchAssoc($set);
+		return (int) $rec["mnr"];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLevelData(int $a_id = 0) : array
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		if ($a_id > 0)
+		{
+			$and = " AND id = ".$ilDB->quote($a_id, "integer");
+		}
+
+		$set = $ilDB->query("SELECT * FROM skl_level WHERE ".
+			" skill_id = ".$ilDB->quote($id, "integer").
+			$and.
+			" ORDER BY nr"
+		);
+		$levels = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			if ($a_id > 0)
+			{
+				return $rec;
+			}
+			$levels[] = $rec;
+		}
+		return $levels;
+	}
+
+	/**
+	 * Lookup level property
+	 *
+	 * @param	int		level id
+	 * @param	string $a_prop
+	 * @return	mixed	property value
+	 */
+	protected function lookupLevelProperty(int $a_id, string $a_prop)
+	{
+		$ilDB = $this->db;
+
+		$set = $ilDB->query("SELECT $a_prop FROM skl_level WHERE ".
+			" id = ".$ilDB->quote($a_id, "integer")
+		);
+		$rec = $ilDB->fetchAssoc($set);
+		return $rec[$a_prop];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function lookupLevelTitle(int $a_id) : string
+	{
+		$this->lookupLevelProperty($a_id, "title");
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function lookupLevelDescription(int $a_id) : string
+	{
+		$this->lookupLevelProperty($a_id, "description");
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function lookupLevelSkillId(int $a_id) : int
+	{
+		$this->lookupLevelProperty($a_id, "skill_id");
+	}
+
+	/**
+	 * Write level property
+	 *
+	 * @param int $a_id
+	 * @param string $a_prop
+	 * @param $a_value
+	 * @param string $a_type
+	 */
+	protected function writeLevelProperty(int $a_id, string $a_prop, $a_value, string $a_type)
+	{
+		$ilDB = $this->db;
+
+		$ilDB->update("skl_level", array(
+			$a_prop => array($a_type, $a_value),
+		), array(
+			"id" => array("integer", $a_id),
+		));
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function writeLevelTitle(int $a_id, string $a_title)
+	{
+		$this->writeLevelProperty($a_id, "title", $a_title, "text");
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function writeLevelDescription(int $a_id, string $a_description)
+	{
+		$this->writeLevelProperty($a_id, "description", $a_description, "clob");
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function updateLevelOrder(array $order)
+	{
+		$ilDB = $this->db;
+
+		$cnt = 1;
+		foreach ($order as $id => $o)
+		{
+			$ilDB->manipulate("UPDATE skl_level SET ".
+				" nr = ".$ilDB->quote($cnt, "integer").
+				" WHERE id = ".$ilDB->quote($id, "integer")
+			);
+			$cnt++;
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function deleteLevel(int $a_id)
+	{
+		$ilDB = $this->db;
+
+		$ilDB->manipulate("DELETE FROM skl_level WHERE "
+			." id = ".$ilDB->quote($a_id, "integer")
+		);
+
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function fixLevelNumbering()
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$set = $ilDB->query("SELECT id, nr FROM skl_level WHERE ".
+			" skill_id = ".$ilDB->quote($id, "integer").
+			" ORDER BY nr ASC"
+		);
+		$cnt = 1;
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$ilDB->manipulate("UPDATE skl_level SET ".
+				" nr = ".$ilDB->quote($cnt, "integer").
+				" WHERE id = ".$ilDB->quote($rec["id"], "integer")
+			);
+			$cnt++;
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSkillForLevelId(int $a_level_id)
+	{
+		$ilDB = $this->db;
+
+		$set = $ilDB->query("SELECT * FROM skl_level WHERE ".
+			" id = ".$ilDB->quote($a_level_id, "integer")
+		);
+		$skill = null;
+		if ($rec = $ilDB->fetchAssoc($set))
+		{
+			if (ilSkillTreeNode::isInTree($rec["skill_id"]))
+			{
+				$skill = new ilBasicSkill($rec["skill_id"]);
+			}
+		}
+		return $skill;
+	}
+}

--- a/Services/Skill/classes/class.ilBasicSkillTreeDBRepository.php
+++ b/Services/Skill/classes/class.ilBasicSkillTreeDBRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+class ilBasicSkillTreeDBRepository implements ilBasicSkillTreeRepository
+{
+	/**
+	 * @var ilDBInterface
+	 */
+	protected $db;
+
+	public function __construct(ilDBInterface $db)
+	{
+		$this->db = $db;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCommonSkillIdForImportId(ilSkillTree $tree, int $a_source_inst_id, int $a_skill_import_id,
+												int $a_tref_import_id = 0) : array
+	{
+		$ilDB = $this->db;
+
+		$template_ids = array();
+		if ($a_tref_import_id > 0)
+		{
+			$skill_node_type = "sktp";
+
+			// get all matching tref nodes
+			$set = $ilDB->query("SELECT * FROM skl_tree_node n JOIN skl_tree t ON (n.obj_id = t.child) ".
+				" WHERE n.import_id = ".$ilDB->quote("il_".((int)$a_source_inst_id)."_sktr_".$a_tref_import_id, "text").
+				" ORDER BY n.creation_date DESC ");
+			while ($rec = $ilDB->fetchAssoc($set))
+			{
+				if (($t = ilSkillTemplateReference::_lookupTemplateId($rec["obj_id"])) > 0)
+				{
+					$template_ids[$t] = $rec["obj_id"];
+				}
+			}
+		}
+		else
+		{
+			$skill_node_type = "skll";
+		}
+		$set = $ilDB->query("SELECT * FROM skl_tree_node n JOIN skl_tree t ON (n.obj_id = t.child) ".
+			" WHERE n.import_id = ".$ilDB->quote("il_".((int)$a_source_inst_id)."_".$skill_node_type."_".$a_skill_import_id, "text").
+			" ORDER BY n.creation_date DESC ");
+		$results = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$matching_trefs = array();
+			if ($a_tref_import_id > 0)
+			{
+				$skill_template_id = $tree->getTopParentNodeId($rec["obj_id"]);
+
+				// check of skill is in template
+				foreach ($template_ids as $templ => $tref)
+				{
+					if ($skill_template_id == $templ)
+					{
+						$matching_trefs[] = $tref;
+					}
+				}
+			}
+			else
+			{
+				$matching_trefs = array(0);
+			}
+
+			foreach ($matching_trefs as $t)
+			{
+				$results[] = array("skill_id" => $rec["obj_id"], "tref_id" => $t, "creation_date" => $rec["creation_date"]);
+			}
+		}
+		return $results;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLevelIdForImportId(int $a_source_inst_id, int $a_level_import_id) : array
+	{
+		$ilDB = $this->db;
+
+		$set = $ilDB->query("SELECT * FROM skl_level l JOIN skl_tree t ON (l.skill_id = t.child) " .
+			" WHERE l.import_id = " . $ilDB->quote("il_" . ((int)$a_source_inst_id) . "_sklv_" . $a_level_import_id, "text") .
+			" ORDER BY l.creation_date DESC ");
+		$results = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$results[] = array("level_id" => $rec["id"], "creation_date" => $rec["creation_date"]);
+		}
+		return $results;
+	}
+}

--- a/Services/Skill/classes/class.ilBasicSkillUserLevelDBRepository.php
+++ b/Services/Skill/classes/class.ilBasicSkillUserLevelDBRepository.php
@@ -1,0 +1,511 @@
+<?php
+
+class ilBasicSkillUserLevelDBRepository implements ilBasicSkillUserLevelRepository
+{
+	/**
+	 * @var ilDBInterface
+	 */
+	protected $db;
+
+	/**
+	 * @var int
+	 */
+	protected $id;
+
+	/**
+	 * @var array
+	 */
+	protected $levels;
+
+	public function __construct(ilDBInterface $db, int $id = null, array $levels = null)
+	{
+		$this->db = $db;
+		$this->id = $id;
+		$this->levels = $levels;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function deleteUserLevelsOfSkill()
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
+			." skill_id = ".$ilDB->quote($id, "integer")
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function resetUserSkillLevelStatus(bool $update, int $trigger_obj_id, $status_date, int $a_user_id,
+											  int $a_skill_id, int $a_tref_id = 0, int $a_trigger_ref_id = 0,
+											  bool $a_self_eval = false)
+	{
+		$ilDB = $this->db;
+
+		if ($update)
+		{
+			// this will only be set in self eval case, means this will always have a $rec
+			$now = ilUtil::now();
+			$ilDB->manipulate("UPDATE skl_user_skill_level SET ".
+				" level_id = ".$ilDB->quote(0, "integer").",".
+				" status_date = ".$ilDB->quote($now, "timestamp").
+				" WHERE user_id = ".$ilDB->quote($a_user_id, "integer").
+				" AND status_date = ".$ilDB->quote($status_date, "timestamp").
+				" AND skill_id = ".$ilDB->quote($a_skill_id, "integer").
+				" AND status = ".$ilDB->quote(ilBasicSkill::ACHIEVED, "integer").
+				" AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer").
+				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+				" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+			);
+		}
+		else
+		{
+			$now = ilUtil::now();
+			$ilDB->manipulate("INSERT INTO skl_user_skill_level ".
+				"(level_id, user_id, tref_id, status_date, skill_id, status, valid, trigger_ref_id,".
+				"trigger_obj_id, trigger_obj_type, trigger_title, self_eval, unique_identifier) VALUES (".
+				$ilDB->quote(0, "integer").",".
+				$ilDB->quote($a_user_id, "integer").",".
+				$ilDB->quote((int) $a_tref_id, "integer").",".
+				$ilDB->quote($now, "timestamp").",".
+				$ilDB->quote($a_skill_id, "integer").",".
+				$ilDB->quote(ilBasicSkill::ACHIEVED, "integer").",".
+				$ilDB->quote(1, "integer").",".
+				$ilDB->quote($a_trigger_ref_id, "integer").",".
+				$ilDB->quote($trigger_obj_id, "integer").",".
+				$ilDB->quote("", "text").",".
+				$ilDB->quote("", "text").",".
+				$ilDB->quote($a_self_eval, "integer").",".
+				$ilDB->quote("", "text").
+				")");
+		}
+
+		$ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
+			." user_id = ".$ilDB->quote($a_user_id, "integer")
+			." AND skill_id = ".$ilDB->quote($a_skill_id, "integer")
+			." AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer")
+			." AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer")
+			." AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function hasRecentSelfEvaluation(int $trigger_obj_id, int $a_user_id, int $a_skill_id, int $a_tref_id = 0, int $a_trigger_ref_id = 0)
+	{
+		$ilDB = $this->db;
+
+		$recent = "";
+
+		$ilDB->setLimit(1);
+		$set = $ilDB->query("SELECT * FROM skl_user_skill_level WHERE ".
+			"skill_id = ".$ilDB->quote($a_skill_id, "integer")." AND ".
+			"user_id = ".$ilDB->quote($a_user_id, "integer")." AND ".
+			"tref_id = ".$ilDB->quote((int) $a_tref_id, "integer")." AND ".
+			"trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer")." AND ".
+			"self_eval = ".$ilDB->quote(1, "integer").
+			" ORDER BY status_date DESC"
+		);
+		$rec = $ilDB->fetchAssoc($set);
+		$status_day = substr($rec["status_date"], 0, 10);
+		$today = substr(ilUtil::now(), 0, 10);
+		if ($rec["valid"] && $rec["status"] == ilBasicSkill::ACHIEVED && $status_day == $today)
+		{
+			$recent = $rec["status_date"];
+		}
+
+		return $recent;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getNewAchievementsPerUser(string $a_timestamp, string $a_timestamp_to = null,
+											  int $a_user_id = 0, int $a_self_eval = 0) : array
+	{
+		$ilDB = $this->db;
+
+		$to = (!is_null($a_timestamp_to))
+			? " AND status_date <= ".$ilDB->quote($a_timestamp_to, "timestamp")
+			: "";
+
+		$user = ($a_user_id > 0)
+			? " AND user_id = ".$ilDB->quote($a_user_id, "integer")
+			: "";
+
+		$set = $ilDB->query("SELECT * FROM skl_user_skill_level ".
+			" WHERE status_date >= ".$ilDB->quote($a_timestamp, "timestamp").
+			" AND valid = ".$ilDB->quote(1, "integer").
+			" AND status = ".$ilDB->quote(ilBasicSkill::ACHIEVED, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
+			$to.
+			$user.
+			" ORDER BY user_id, status_date ASC ");
+		$achievments = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$achievments[$rec["user_id"]][] = $rec;
+		}
+
+		return $achievments;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function writeUserSkillLevelStatus(int $skill_id, int $trigger_ref_id, int $trigger_obj_id,
+											  string $trigger_title, string $trigger_type, bool $update, $status_date,
+											  int $a_level_id, int $a_user_id, int $a_tref_id = 0,
+											  int $a_status = ilBasicSkill::ACHIEVED, bool $a_force = false,
+											  bool $a_self_eval = false, string $a_unique_identifier = "")
+	{
+		$ilDB = $this->db;
+
+		if ($update)
+		{
+			// this will only be set in self eval case, means this will always have a $rec
+			$now = ilUtil::now();
+			$ilDB->manipulate("UPDATE skl_user_skill_level SET ".
+				" level_id = ".$ilDB->quote($a_level_id, "integer").",".
+				" status_date = ".$ilDB->quote($now, "timestamp").
+				" WHERE user_id = ".$ilDB->quote($a_user_id, "integer").
+				" AND status_date = ".$ilDB->quote($status_date, "timestamp").
+				" AND skill_id = ".$ilDB->quote($skill_id, "integer").
+				" AND status = ".$ilDB->quote($a_status, "integer").
+				" AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer").
+				" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+				" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+			);
+		}
+		else
+		{
+			if ($a_unique_identifier != "")
+			{
+				$ilDB->manipulate("DELETE FROM skl_user_skill_level WHERE ".
+					" user_id = ".$ilDB->quote($a_user_id, "integer").
+					" AND tref_id = ".$ilDB->quote($a_tref_id, "integer").
+					" AND skill_id = ".$ilDB->quote($skill_id, "integer").
+					" AND trigger_ref_id = ".$ilDB->quote($trigger_ref_id, "integer").
+					" AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer").
+					" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
+					" AND unique_identifier = ".$ilDB->quote($a_unique_identifier, "text")
+				);
+			}
+
+			$now = ilUtil::now();
+			$ilDB->manipulate("INSERT INTO skl_user_skill_level ".
+				"(level_id, user_id, tref_id, status_date, skill_id, status, valid, trigger_ref_id,".
+				"trigger_obj_id, trigger_obj_type, trigger_title, self_eval, unique_identifier) VALUES (".
+				$ilDB->quote($a_level_id, "integer").",".
+				$ilDB->quote($a_user_id, "integer").",".
+				$ilDB->quote((int) $a_tref_id, "integer").",".
+				$ilDB->quote($now, "timestamp").",".
+				$ilDB->quote($skill_id, "integer").",".
+				$ilDB->quote($a_status, "integer").",".
+				$ilDB->quote(1, "integer").",".
+				$ilDB->quote($trigger_ref_id, "integer").",".
+				$ilDB->quote($trigger_obj_id, "integer").",".
+				$ilDB->quote($trigger_type, "text").",".
+				$ilDB->quote($trigger_title, "text").",".
+				$ilDB->quote($a_self_eval, "integer").",".
+				$ilDB->quote($a_unique_identifier, "text").
+				")");
+		}
+
+		// fix (removed level_id and added skill id, since table should hold only
+		// one entry per skill)
+		$ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
+			." user_id = ".$ilDB->quote($a_user_id, "integer")
+			." AND skill_id = ".$ilDB->quote($skill_id, "integer")
+			." AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer")
+			." AND trigger_obj_id = ".$ilDB->quote($trigger_obj_id, "integer")
+			." AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+		);
+
+		if ($a_status == ilBasicSkill::ACHIEVED)
+		{
+			$ilDB->manipulate("INSERT INTO skl_user_has_level ".
+				"(level_id, user_id, tref_id, status_date, skill_id, trigger_ref_id, trigger_obj_id, trigger_obj_type, trigger_title, self_eval) VALUES (".
+				$ilDB->quote($a_level_id, "integer").",".
+				$ilDB->quote($a_user_id, "integer").",".
+				$ilDB->quote($a_tref_id, "integer").",".
+				$ilDB->quote($now, "timestamp").",".
+				$ilDB->quote($skill_id, "integer").",".
+				$ilDB->quote($trigger_ref_id, "integer").",".
+				$ilDB->quote($trigger_obj_id, "integer").",".
+				$ilDB->quote($trigger_type, "text").",".
+				$ilDB->quote($trigger_title, "text").",".
+				$ilDB->quote($a_self_eval, "integer").
+				")");
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function removeAllUserSkillLevelStatusOfObject(int $a_user_id, int $a_trigger_obj_id, bool $a_self_eval = false,
+														  string $a_unique_identifier = "") : bool
+	{
+		$ilDB = $this->db;
+
+		$changed = false;
+
+		$aff_rows = $ilDB->manipulate("DELETE FROM skl_user_skill_level WHERE "
+			." user_id = ".$ilDB->quote($a_user_id, "integer")
+			." AND trigger_obj_id = ".$ilDB->quote($a_trigger_obj_id, "integer")
+			." AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+			." AND unique_identifier = ".$ilDB->quote($a_unique_identifier, "text")
+		);
+		if ($aff_rows > 0)
+		{
+			$changed = true;
+		}
+
+		$aff_rows = $ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
+			." user_id = ".$ilDB->quote($a_user_id, "integer")
+			." AND trigger_obj_id = ".$ilDB->quote($a_trigger_obj_id, "integer")
+			." AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+		);
+		if ($aff_rows > 0)
+		{
+			$changed = true;
+		}
+		return $changed;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function removeAllUserData(int $a_user_id)
+	{
+		$ilDB = $this->db;
+
+		$ilDB->manipulate("DELETE FROM skl_user_skill_level WHERE "
+			." user_id = ".$ilDB->quote($a_user_id, "integer")
+		);
+		$ilDB->manipulate("DELETE FROM skl_user_has_level WHERE "
+			." user_id = ".$ilDB->quote($a_user_id, "integer")
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMaxLevelPerType(int $a_tref_id, string $a_type, int $a_user_id = 0, int $a_self_eval = 0) : int
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+		$levels = $this->levels;
+
+		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
+			" WHERE trigger_obj_type = ".$ilDB->quote($a_type, "text").
+			" AND skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+		);
+
+		$has_level = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$has_level[$rec["level_id"]] = true;
+		}
+		$max_level = 0;
+		foreach ($levels as $l)
+		{
+			if (isset($has_level[$l["id"]]))
+			{
+				$max_level = $l["id"];
+			}
+		}
+		return $max_level;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getAllLevelEntriesOfUser(int $a_tref_id, int $a_user_id = 0, int $a_self_eval = 0) : array
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$set = $ilDB->query($q = "SELECT * FROM skl_user_has_level ".
+			" WHERE skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
+			" ORDER BY status_date DESC"
+		);
+
+		$levels = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$levels[] = $rec;
+		}
+		return $levels;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getAllHistoricLevelEntriesOfUser(int $a_tref_id, int $a_user_id = 0, int $a_eval_by = 0) : array
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$by = ($a_eval_by != ilBasicSkill::EVAL_BY_ALL)
+			? " AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+			: "";
+
+		$set = $ilDB->query($q = "SELECT * FROM skl_user_skill_level ".
+			" WHERE skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			$by.
+			" ORDER BY status_date DESC"
+		);
+		$levels = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$levels[] = $rec;
+		}
+		return $levels;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMaxLevelPerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0) : int
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+		$levels = $this->levels;
+
+		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
+			" WHERE trigger_obj_id = ".$ilDB->quote($a_object_id, "integer").
+			" AND skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+		);
+
+		$has_level = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$has_level[$rec["level_id"]] = true;
+		}
+		$max_level = 0;
+		foreach ($levels as $l)
+		{
+			if (isset($has_level[$l["id"]]))
+			{
+				$max_level = $l["id"];
+			}
+		}
+		return $max_level;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getMaxLevel(int $a_tref_id, int $a_user_id = 0, int $a_self_eval = 0) : int
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+		$levels = $this->levels;
+
+		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
+			" WHERE skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer")
+		);
+
+		$has_level = array();
+		while ($rec = $ilDB->fetchAssoc($set))
+		{
+			$has_level[$rec["level_id"]] = true;
+		}
+		$max_level = 0;
+		foreach ($levels as $l)
+		{
+			if (isset($has_level[$l["id"]]))
+			{
+				$max_level = $l["id"];
+			}
+		}
+		return $max_level;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function hasSelfEvaluated(int $a_user_id, int $a_skill_id, int $a_tref_id) : bool
+	{
+		$ilDB = $this->db;
+
+		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
+			" WHERE skill_id = ".$ilDB->quote((int) $a_skill_id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote(1, "integer")
+		);
+
+		if ($rec = $ilDB->fetchAssoc($set))
+		{
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLastLevelPerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0)
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$ilDB->setLimit(1);
+		$set = $ilDB->query($q = "SELECT level_id FROM skl_user_has_level ".
+			" WHERE trigger_obj_id = ".$ilDB->quote($a_object_id, "integer").
+			" AND skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
+			" ORDER BY status_date DESC"
+		);
+
+		$rec = $ilDB->fetchAssoc($set);
+
+		return $rec["level_id"];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLastUpdatePerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0)
+	{
+		$ilDB = $this->db;
+		$id = $this->id;
+
+		$ilDB->setLimit(1);
+		$set = $ilDB->query($q = "SELECT status_date FROM skl_user_has_level ".
+			" WHERE trigger_obj_id = ".$ilDB->quote($a_object_id, "integer").
+			" AND skill_id = ".$ilDB->quote($id, "integer").
+			" AND tref_id = ".$ilDB->quote((int) $a_tref_id, "integer").
+			" AND user_id = ".$ilDB->quote($a_user_id, "integer").
+			" AND self_eval = ".$ilDB->quote($a_self_eval, "integer").
+			" ORDER BY status_date DESC"
+		);
+
+		$rec = $ilDB->fetchAssoc($set);
+
+		return $rec["status_date"];
+	}
+}

--- a/Services/Skill/classes/class.ilSkillObjectAdapter.php
+++ b/Services/Skill/classes/class.ilSkillObjectAdapter.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Class ilBasicSkillObjectAdapter
+ */
+class ilSkillObjectAdapter implements ilSkillObjectAdapterInterface
+{
+	/**
+	 * Constructor
+	 */
+	public function __construct()
+	{
+
+	}
+
+	/**
+	 * Get object id for reference id
+	 *
+	 * @param int $a_ref_id
+	 * @return int
+	 */
+	public function getObjIdForRefId(int $a_ref_id) : int
+	{
+		return ilObject::_lookupObjId($a_ref_id);
+	}
+
+	/**
+	 * Get object type for object id
+	 *
+	 * @param int $a_obj_id
+	 * @return string
+	 */
+	public function getTypeForObjId(int $a_obj_id) : string
+	{
+		return ilObject::_lookupType($a_obj_id);
+	}
+
+	/**
+	 * Get object title for object id
+	 *
+	 * @param int $a_obj_id
+	 * @return string
+	 */
+	public function getTitleForObjId(int $a_obj_id) : string
+	{
+		return ilObject::_lookupTitle($a_obj_id);
+	}
+
+
+}

--- a/Services/Skill/interfaces/interface.ilBasicSkillLevelRepository.php
+++ b/Services/Skill/interfaces/interface.ilBasicSkillLevelRepository.php
@@ -1,0 +1,111 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Interface ilBasicSkillLevelRepository
+ */
+interface ilBasicSkillLevelRepository {
+
+	/**
+	 * Delete levels of a skill
+	 */
+	public function deleteLevelsOfSkill();
+
+
+	/**
+	 * Add new level
+	 *
+	 * @param string $a_title
+	 * @param string $a_description
+	 * @param string $a_import_id
+	 */
+	public function addLevel(string $a_title, string $a_description, string $a_import_id = "");
+
+
+	/**
+	 * Get level data
+	 *
+	 * @param int $a_id
+	 * @return array level data
+	 */
+	public function getLevelData(int $a_id = 0) : array;
+
+
+	/**
+	 * Lookup level title
+	 *
+	 * @param int $a_id level id
+	 * @return string level title
+	 */
+	public function lookupLevelTitle(int $a_id) : string;
+
+
+	/**
+	 * Lookup level description
+	 *
+	 * @param int $a_id level id
+	 * @return string level description
+	 */
+	public function lookupLevelDescription(int $a_id) : string;
+
+
+	/**
+	 * Lookup level skill id
+	 *
+	 * @param int $a_id level id
+	 * @return int skill id
+	 */
+	public function lookupLevelSkillId(int $a_id) : int;
+
+
+	/**
+	 * Write level title
+	 *
+	 * @param int $a_id level id
+	 * @param string $a_title level title
+	 */
+	public function writeLevelTitle(int $a_id, string $a_title);
+
+
+	/**
+	 * Write level description
+	 *
+	 * @param int $a_id level id
+	 * @param string $a_description level description
+	 */
+	public function writeLevelDescription(int $a_id, string $a_description);
+
+
+	/**
+	 * Update level order
+	 *
+	 * @param array $order
+	 */
+	public function updateLevelOrder(array $order);
+
+
+	/**
+	 * Delete level
+	 *
+	 * @param int $a_id
+	 */
+	public function deleteLevel(int $a_id);
+
+
+	/**
+	 * Fix level numbering
+	 *
+	 */
+	public function fixLevelNumbering();
+
+
+	/**
+	 * Get skill for level id
+	 *
+	 * @param int $a_level_id
+	 * @return null|ilBasicSkill
+	 */
+	public function getSkillForLevelId(int $a_level_id);
+	
+}

--- a/Services/Skill/interfaces/interface.ilBasicSkillTreeRepository.php
+++ b/Services/Skill/interfaces/interface.ilBasicSkillTreeRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Interface ilBasicSkillTreeRepository
+ */
+interface ilBasicSkillTreeRepository {
+
+	/**
+	 * Get common skill ids for import IDs (newest first)
+	 *
+	 * @param ilSkillTree $tree skill tree
+	 * @param int $a_source_inst_id source installation id, must be <>0
+	 * @param int $a_skill_import_id source skill id (type basic skill ("skll") or basic skill template ("sktp"))
+	 * @param int $a_tref_import_id source template reference id (if > 0 skill_import_id will be of type "sktp")
+	 *
+	 * @return array array of common skill ids, keys are "skill_id", "tref_id", "creation_date"
+	 */
+	public function getCommonSkillIdForImportId(ilSkillTree $tree, int $a_source_inst_id, int $a_skill_import_id,
+												int $a_tref_import_id = 0) : array;
+
+
+	/**
+	 * Get level ids for import IDs (newest first)
+	 *
+	 * @param int $a_source_inst_id source installation id, must be <>0
+	 * @param int $a_level_import_id source level id
+	 *
+	 * @return array array of common skill ids, keys are "level_id", "creation_date"
+	 */
+	public function getLevelIdForImportId(int $a_source_inst_id, int $a_level_import_id) : array;
+}

--- a/Services/Skill/interfaces/interface.ilBasicSkillUserLevelRepository.php
+++ b/Services/Skill/interfaces/interface.ilBasicSkillUserLevelRepository.php
@@ -1,0 +1,211 @@
+<?php
+
+/* Copyright (c) 1998-2019 ILIAS open source, Extended GPL, see docs/LICENSE */
+
+/**
+ * Interface ilBasicSkillUserLevelRepository
+ */
+interface ilBasicSkillUserLevelRepository {
+
+	/**
+	 * Delete user levels of a skill
+	 */
+	public function deleteUserLevelsOfSkill();
+
+
+	/**
+	 * Reset skill level status. This is currently only used for self evaluations with a "no competence" level.
+	 * It has to be discussed, how this should be provided for non-self-evaluations.
+	 *
+	 * @param bool $update update or insert
+	 * @param int $trigger_obj_id triggering object id
+	 * @param mixed $status_date date status
+	 * @param int $a_user_id user id
+	 * @param int $a_skill_id skill id
+	 * @param int $a_tref_id skill tref id
+	 * @param int $a_trigger_ref_id triggering repository object ref id
+	 * @param bool $a_self_eval currently needs to be set to true
+	 *
+	 * @throws ilSkillException
+	 */
+	public function resetUserSkillLevelStatus(bool $update, int $trigger_obj_id, $status_date, int $a_user_id,
+											  int $a_skill_id, int $a_tref_id = 0, int $a_trigger_ref_id = 0,
+											  bool $a_self_eval = false);
+
+
+	/**
+	 * Has recent self evaluation. Check if self evaluation for user/object has been done on the same day
+	 * already
+	 *
+	 * @param int $trigger_obj_id triggering object id
+	 * @param int $a_user_id user id
+	 * @param int $a_skill_id skill id
+	 * @param int $a_tref_id skill tref id
+	 * @param int $a_trigger_ref_id triggering repository object ref id
+	 *
+	 * @return mixed
+	 */
+	public function hasRecentSelfEvaluation(int $trigger_obj_id, int $a_user_id, int $a_skill_id, int $a_tref_id = 0,
+											int $a_trigger_ref_id = 0);
+
+
+	/**
+	 * Get new achievements
+	 *
+	 * @param string $a_timestamp
+	 * @param string $a_timestamp_to
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return array
+	 */
+	public function getNewAchievementsPerUser(string $a_timestamp, string $a_timestamp_to = null,
+											  int $a_user_id = 0, int $a_self_eval = 0) : array ;
+
+
+	/**
+	 * Write skill level status
+	 *
+	 * @param int $skill_id skill id
+	 * @param int $trigger_ref_id triggering repository object ref id
+	 * @param int $trigger_obj_id triggering object id
+	 * @param string $trigger_title triggering object title
+	 * @param string $trigger_type triggering object type
+	 * @param bool $update update or insert
+	 * @param mixed $status_date date status
+	 * @param int $a_level_id skill level id
+	 * @param int $a_user_id user id
+	 * @param int $a_tref_id skill tref id
+	 * @param int $a_status DEPRECATED, always use ilBasicSkill::ACHIEVED
+	 * @param bool $a_force DEPRECATED
+	 * @param bool $a_self_eval self evaluation
+	 * @param string $a_unique_identifier a  unique identifier (should be used with trigger_ref_id > 0)
+	 */
+	public function writeUserSkillLevelStatus(int $skill_id, int $trigger_ref_id, int $trigger_obj_id,
+											  string $trigger_title, string $trigger_type, bool $update, $status_date,
+											  int $a_level_id, int $a_user_id, int $a_tref_id = 0,
+											  int $a_status = ilBasicSkill::ACHIEVED, bool $a_force = false,
+											  bool $a_self_eval = false, string $a_unique_identifier = "");
+
+
+	/**
+	 * Remove a user skill completely
+	 *
+	 * @param int $a_user_id user id
+	 * @param int $a_trigger_obj_id triggering repository object obj id
+	 * @param bool $a_self_eval currently needs to be set to true
+	 * @param string $a_unique_identifier unique identifier string
+	 *
+	 * @return bool true, if entries have been deleted, otherwise false
+	 */
+	public function removeAllUserSkillLevelStatusOfObject(int $a_user_id, int $a_trigger_obj_id, bool $a_self_eval = false,
+														  string $a_unique_identifier = "") : bool;
+
+
+	/**
+	 * Remove all data of a user
+	 *
+	 * @param int $a_user_id
+	 */
+	public function removeAllUserData(int $a_user_id);
+
+
+	/**
+	 * Get max levels per type
+	 *
+	 * @param int $a_tref_id
+	 * @param string $a_type
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return int
+	 */
+	public function getMaxLevelPerType(int $a_tref_id, string $a_type, int $a_user_id = 0, int $a_self_eval = 0) : int ;
+
+
+	/**
+	 * Get all level entries
+	 *
+	 * @param int $a_tref_id
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return array
+	 */
+	public function getAllLevelEntriesOfUser(int $a_tref_id, int $a_user_id = 0, int $a_self_eval = 0) : array;
+
+
+	/**
+	 * Get all historic level entries
+	 *
+	 * @param int $a_tref_id
+	 * @param int $a_user_id
+	 * @param int $a_eval_by
+	 *
+	 * @return array
+	 */
+	public function getAllHistoricLevelEntriesOfUser(int $a_tref_id, int $a_user_id = 0, int $a_eval_by = 0) : array;
+
+
+	/**
+	 * Get max levels per object
+	 *
+	 * @param int $a_tref_id
+	 * @param int $a_object_id
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return int
+	 */
+	public function getMaxLevelPerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0) : int;
+
+
+	/**
+	 * Get max levels
+	 *
+	 * @param int $a_tref_id
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return int
+	 */
+	public function getMaxLevel(int $a_tref_id, int $a_user_id = 0, int $a_self_eval = 0) : int;
+
+
+	/**
+	 * Has user self evaluated a skill?
+	 *
+	 * @param int $a_user_id
+	 * @param int $a_skill_id
+	 * @param int $a_tref_id
+	 *
+	 * @return bool
+	 */
+	public function hasSelfEvaluated(int $a_user_id, int $a_skill_id, int $a_tref_id) : bool;
+
+
+	/**
+	 * Get last level set per object
+	 *
+	 * @param int $a_tref_id
+	 * @param int $a_object_id
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return mixed
+	 */
+	public function getLastLevelPerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0);
+
+
+	/**
+	 * Get last update per object
+	 *
+	 * @param int $a_tref_id
+	 * @param int $a_object_id
+	 * @param int $a_user_id
+	 * @param int $a_self_eval
+	 *
+	 * @return mixed
+	 */
+	public function getLastUpdatePerObject(int $a_tref_id, int $a_object_id, int $a_user_id = 0, int $a_self_eval = 0);
+}

--- a/Services/Skill/interfaces/interface.ilSkillObjectAdapterInterface.php
+++ b/Services/Skill/interfaces/interface.ilSkillObjectAdapterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Interface ilBasicSkillObjectAdapter
+ */
+interface ilSkillObjectAdapterInterface
+{
+	/**
+	 * Get object id for reference id
+	 *
+	 * @param int $a_ref_id
+	 * @return int
+	 */
+	public function getObjIdForRefId(int $a_ref_id) : int;
+
+	/**
+	 * Get object type for object id
+	 *
+	 * @param int $a_obj_id
+	 * @return string
+	 */
+	public function getTypeForObjId(int $a_obj_id) : string;
+
+	/**
+	 * Get object title for object id
+	 *
+	 * @param int $a_obj_id
+	 * @return string
+	 */
+	public function getTitleForObjId(int $a_obj_id) : string;
+}


### PR DESCRIPTION
This PR provides some refactoring for the Skill Management. It includes:

- Move all persistence to new repository classes (`ilBasicSkillLevelDBRepository.php`, `ilBasicSkillUserLevelDBRepository.php`, `ilBasicSkillTreeDBRepository.php`)
- Define interfaces to the repository classes
- Instantiate the repositories in the contructor of `ilBasicSkill`
- Use a new `ilSkillObjectAdapter` when calling static `ilObject` methods
- Add type hints
- Add return type declarations
- Add or correct PHPDoc
- Remove includes



To do:

- [ ] Just pass ilDB as a parameter to the repositories, remove the other ones
- [ ] PhpUnit tests