### PR TITLE
fix 28488, 28237 - engageTools in mainbar.js

### DIFF
--- a/src/UI/templates/js/MainControls/mainbar.js
+++ b/src/UI/templates/js/MainControls/mainbar.js
@@ -7,11 +7,17 @@ il.UI.maincontrols = il.UI.maincontrols || {};
 		var mappings = {},
 			external_commands = {
 				/**
-				 * Engage a certain tool
+				 * Engage a certain tool (or entry)
 				 */
 				engageTool: function(mapping_id) {
 					var tool_id = mappings[mapping_id];
-					this.model.actions.engageTool(tool_id);
+					if(Object.keys(this.model.getState().tools).includes(tool_id)) {
+						this.model.actions.engageTool(tool_id);
+					}
+					if(Object.keys(this.model.getState().entries).includes(tool_id)) {
+						this.model.actions.engageEntry(tool_id);
+					}
+
 					this.renderer.render(this.model.getState());
 				},
 				/**


### PR DESCRIPTION
 now triggers regular entries as well;
LSO maps tools to entries, and mainbar.js used to trigger tools only.
https://mantis.ilias.de/view.php?id=28488
https://mantis.ilias.de/view.php?id=28237