### PR TITLE
LSO: do not fold Tools into Entries

### DIFF
--- a/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
+++ b/Modules/LearningSequence/classes/GlobalScreen/class.ilLSViewLayoutProvider.php
@@ -54,13 +54,15 @@ class ilLSViewLayoutProvider extends AbstractModificationProvider implements Mod
         return $this->globalScreen()->layout()->factory()->mainbar()
             ->withModification(
                 function (MainBar $mainbar) : ?MainBar {
-                    $entries = array_merge(
-                        $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS),
-                        $mainbar->getToolEntries()
-                    );
+                    $entries = $this->data_collection->get(\ilLSPlayer::GS_DATA_LS_MAINBARCONTROLS);
+                    $tools = $mainbar->getToolEntries();
                     $mainbar = $mainbar->withClearedEntries();
+
                     foreach ($entries as $key => $entry) {
                         $mainbar = $mainbar->withAdditionalEntry($key, $entry);
+                    }
+                    foreach ($tools as $key => $entry) {
+                        $mainbar = $mainbar->withAdditionalToolEntry($key, $entry);
                     }
                     return $mainbar;
                 }


### PR DESCRIPTION
Hi Alex, 
als follow-up zu https://github.com/leifos-gmbh/ILIAS/pull/26: 
Die Tools bleiben jetzt an Ort und Stelle, nur die Entries werden zurückgesetzt.
