### PR TITLE
#28744: highlight (current) nodes in ToC

### DIFF
--- a/Modules/LearningModule/Presentation/classes/class.ilLMTOCExplorerGUI.php
+++ b/Modules/LearningModule/Presentation/classes/class.ilLMTOCExplorerGUI.php
@@ -486,7 +486,6 @@ class ilLMTOCExplorerGUI extends ilLMExplorerGUI
         ->end()
         ->end()
         ->end();*/
-
     }
 
     /**
@@ -521,8 +520,8 @@ class ilLMTOCExplorerGUI extends ilLMExplorerGUI
             }
             $node_toc->end();
         } else {
-            $toc->item($current_node["title"], $current_node["child"]);
+            $highlight = $this->isNodeHighlighted($current_node);
+            $toc->item($current_node["title"], $current_node["child"], null, $highlight);
         }
     }
-
 }

--- a/Modules/LearningSequence/classes/Player/LSTOCBuilder.php
+++ b/Modules/LearningSequence/classes/Player/LSTOCBuilder.php
@@ -68,13 +68,14 @@ class LSTOCBuilder implements TOCBuilder
     /**
      * @inheritdoc
      */
-    public function item(string $label, int $parameter, $state = null) : TOCBuilder
+    public function item(string $label, int $parameter, $state = null, bool $current = false) : TOCBuilder
     {
         $item = [
             'label' => $label,
             'command' => $this->command,
             'parameter' => $parameter,
-            'state' => $state
+            'state' => $state,
+            'current' => $current
         ];
         $this->structure['childs'][] = $item;
         return $this;

--- a/Modules/LearningSequence/classes/Player/class.ilLSTOCGUI.php
+++ b/Modules/LearningSequence/classes/Player/class.ilLSTOCGUI.php
@@ -129,4 +129,12 @@ class ilLSTOCGUI extends ilExplorerBaseGUI
     {
         return !is_null($a_node['parameter']);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isNodeHighlighted($a_node)
+    {
+        return $a_node['current'];
+    }
 }

--- a/Modules/LearningSequence/test/LSTOCBuilderTest.php
+++ b/Modules/LearningSequence/test/LSTOCBuilderTest.php
@@ -36,14 +36,14 @@ class LSTOCBuilderTest extends TestCase
         $expected = [
             "label" => "","command" => "","parameter" => null,"state" => null,"childs" => [
                 ["label" => "node1","command" => "","parameter" => null,"state" => null,"childs" => [
-                    ["label" => "item1.1","command" => "","parameter" => 1,"state" => null],
-                    ["label" => "item1.2","command" => "","parameter" => 2,"state" => null]
+                    ["label" => "item1.1","command" => "","parameter" => 1,"state" => null,"current" => false],
+                    ["label" => "item1.2","command" => "","parameter" => 2,"state" => null,"current" => false]
                 ]],
-            ["label" => "item2","command" => "","parameter" => 3,"state" => null],
+            ["label" => "item2","command" => "","parameter" => 3,"state" => null, "current" => false],
             ["label" => "node3","command" => "","parameter" => null,"state" => null,"childs" => [
-                ["label" => "item3.1","command" => "","parameter" => 4,"state" => null],
+                ["label" => "item3.1","command" => "","parameter" => 4,"state" => null,"current" => false],
                 ["label" => "node3.2","command" => "","parameter" => 5,"state" => null,"childs" => [
-                    ["label" => "item3.2.1","command" => "","parameter" => 6,"state" => null]
+                    ["label" => "item3.2.1","command" => "","parameter" => 6,"state" => null,"current" => false]
                 ]
             ]]]]];
 

--- a/src/KioskMode/TOCBuilder.php
+++ b/src/KioskMode/TOCBuilder.php
@@ -42,7 +42,8 @@ interface TOCBuilder
      * The $parameter can be used to pass additional information to View::updateGet
      * if required, e.g. about a chapter in the content.
      *
-     * @param	mixed $state one of the LP_ constants from TOCBuilder
+     * @param mixed $state one of the LP_ constants from TOCBuilder
+     * @param bool $current is this the currently active item?
      */
-    public function item(string $label, int $parameter, $state = null) : TOCBuilder;
+    public function item(string $label, int $parameter, $state = null, bool $current = false) : TOCBuilder;
 }


### PR DESCRIPTION
This fixes https://mantis.ilias.de/view.php?id=28744
There was actually no mechanism in the ToCBuilder to mark a node as highlighted/current, so please note that this includes an API-extension.